### PR TITLE
schema formatting for spec validation

### DIFF
--- a/rnaget_service/api/models.py
+++ b/rnaget_service/api/models.py
@@ -6,6 +6,7 @@ From Swagger file, with python classes via Bravado
 import pkg_resources
 import yaml
 from bravado_core.spec import Spec
+import json
 
 #
 # Read in the API definition, and parse it with Bravado
@@ -18,7 +19,7 @@ _BRAVADO_CONFIG = {
     'validate_requests': False,
     'validate_responses': False,
     'use_models': True,
-    'validate_swagger_spec': False
+    'validate_swagger_spec': True
 }
 
 _SWAGGER_SPEC = Spec.from_dict(

--- a/rnaget_service/api/rnaget.yaml
+++ b/rnaget_service/api/rnaget.yaml
@@ -22,15 +22,8 @@ paths:
           in: body
           schema:
             $ref: '#/definitions/project'
-            x-example:
-              id: be2ba51c-8dfe-4619-b832-31c4a087a589
-              name: Project X
-              description: example project
-              tags:
-              - test
-              - x
       responses:
-        201:
+        "201":
           description: New project created
           schema:
             $ref: '#/definitions/project'
@@ -38,15 +31,15 @@ paths:
             Location:
               type: string
               format: url
-        400:
+        "400":
           description: Project provided in body does not pass schema validation
           schema:
             $ref: '#/definitions/Error'
-        405:
+        "405":
           description: Forbidden to overwrite project in post
           schema:
             $ref: '#/definitions/Error'
-        500:
+        "500":
           description: Internal error - project not created
           schema:
             $ref: '#/definitions/Error'
@@ -76,13 +69,13 @@ paths:
         required: false
         type: string
       responses:
-        200:
+        "200":
           description: successful operation
           schema:
             type: array
             items:
               $ref: '#/definitions/project'
-        400:
+        "400":
           description: Error
 #      security:
 #      - rna_auth:
@@ -99,13 +92,13 @@ paths:
       - application/xml
       - application/json
       responses:
-        200:
+        "200":
           description: successful operation
           schema:
             type: array
             items:
               $ref: '#/definitions/searchFilter'
-        400:
+        "400":
           description: Error
 #      security:
 #      - rna_auth:
@@ -130,13 +123,13 @@ paths:
         type: string
         format: uuid
       responses:
-        200:
+        "200":
           description: successful operation
           schema:
             $ref: '#/definitions/project'
-        400:
+        "400":
           description: Invalid ID supplied
-        404:
+        "404":
           description: Project not found
 #      security:
 #        - api_key: []
@@ -153,16 +146,8 @@ paths:
           in: body
           schema:
             $ref: '#/definitions/study'
-            x-example:
-              id: be2ba51c-8dfe-4619-b832-31c4a087a589
-              name: Study Z
-              description: example study
-              parentProjectID: be2ba51c-8dfe-4619-b832-31c4a087a589
-              tags:
-              - test
-              - z
       responses:
-        201:
+        "201":
           description: New project created
           schema:
             $ref: '#/definitions/project'
@@ -170,15 +155,15 @@ paths:
             Location:
               type: string
               format: url
-        400:
+        "400":
           description: Project provided in body does not pass schema validation
           schema:
             $ref: '#/definitions/Error'
-        405:
+        "405":
           description: Forbidden to overwrite project in post
           schema:
             $ref: '#/definitions/Error'
-        500:
+        "500":
           description: Internal error - project not created
           schema:
             $ref: '#/definitions/Error'
@@ -208,13 +193,13 @@ paths:
         required: false
         type: string
       responses:
-        200:
+        "200":
           description: successful operation
           schema:
             type: array
             items:
               $ref: '#/definitions/study'
-        400:
+        "400":
           description: Error
 #      security:
 #      - rna_auth:
@@ -231,13 +216,13 @@ paths:
       - application/xml
       - application/json
       responses:
-        200:
+        "200":
           description: successful operation
           schema:
             type: array
             items:
               $ref: '#/definitions/searchFilter'
-        400:
+        "400":
           description: Error
 #      security:
 #      - rna_auth:
@@ -262,13 +247,13 @@ paths:
         type: string
         format: uuid
       responses:
-        200:
+        "200":
           description: successful operation
           schema:
             $ref: '#/definitions/study'
-        400:
+        "400":
           description: Invalid ID supplied
-        404:
+        "404":
           description: Study not found
 #      security:
 #      - api_key: []
@@ -285,12 +270,8 @@ paths:
           in: body
           schema:
             $ref: '#/definitions/expression'
-            x-example:
-              id: be2ba51c-8dfe-4619-b832-31c4a087a589
-              studyID: be2ba51c-8dfe-4619-b832-31c4a087a589
-              URL: 'http://test.data/expressions/download/be2ba51c-8dfe-4619-b832-31c4a087a589'
       responses:
-        201:
+        "201":
           description: New expression created
           schema:
             $ref: '#/definitions/expression'
@@ -298,15 +279,15 @@ paths:
             Location:
               type: string
               format: url
-        400:
+        "400":
           description: Expression provided in body does not pass schema validation
           schema:
             $ref: '#/definitions/Error'
-        405:
+        "405":
           description: Forbidden to overwrite expression in post
           schema:
             $ref: '#/definitions/Error'
-        500:
+        "500":
           description: Internal error - expression not created
           schema:
             $ref: '#/definitions/Error'
@@ -380,13 +361,13 @@ paths:
         items:
           type: string
       responses:
-        200:
+        "200":
           description: Successful operation
           schema:
             type: array
             items:
               $ref: '#/definitions/expression'
-        400:
+        "400":
           description: Error
 #      security:
 #      - rna_auth:
@@ -409,13 +390,13 @@ paths:
         required: false
         type: string
       responses:
-        200:
+        "200":
           description: successful operation
           schema:
             type: array
             items:
               $ref: '#/definitions/expressionSearchFilter'
-        400:
+        "400":
           description: Error
 #      security:
 #      - rna_auth:
@@ -439,13 +420,13 @@ paths:
         required: true
         type: string
       responses:
-        200:
+        "200":
           description: successful operation
           schema:
             $ref: '#/definitions/expression'
-        400:
+        "400":
           description: Invalid ID supplied
-        404:
+        "404":
           description: Expression not found
 #      security:
 #      - api_key: []
@@ -465,11 +446,11 @@ paths:
         required: true
         type: string
       responses:
-        200:
+        "200":
           description: Successful operation
-        400:
+        "400":
           description: Invalid ID supplied
-        404:
+        "404":
           description: File not found
 
   /changelog:
@@ -484,10 +465,8 @@ paths:
           in: body
           schema:
             $ref: '#/definitions/changeLog'
-            x-example:
-              version: 1
       responses:
-        201:
+        "201":
           description: New change log created
           schema:
             $ref: '#/definitions/changeLog'
@@ -495,15 +474,15 @@ paths:
             Location:
               type: string
               format: url
-        400:
+        "400":
           description: Change log provided in body does not pass schema validation
           schema:
             $ref: '#/definitions/Error'
-        405:
+        "405":
           description: Forbidden to overwrite change log in post
           schema:
             $ref: '#/definitions/Error'
-        500:
+        "500":
           description: Internal error - change log not created
           schema:
             $ref: '#/definitions/Error'
@@ -518,7 +497,7 @@ paths:
       - application/xml
       - application/json
       responses:
-        200:
+        "200":
           description: Successful operation
           schema:
             type: array
@@ -526,7 +505,7 @@ paths:
               type: string
             additionalProperties:
               type: string
-        400:
+        "400":
           description: Invalid tag value
 #      security:
 #      - rna_auth:
@@ -550,13 +529,13 @@ paths:
         required: true
         type: string
       responses:
-        200:
+        "200":
           description: Successful operation
           schema:
             $ref: '#/definitions/changeLog'
-        400:
+        "400":
           description: Invalid ID supplied
-        404:
+        "404":
           description: Change log not found
 #      security:
 #      - api_key: []
@@ -581,13 +560,13 @@ paths:
 #        required: true
 #        type: string
 #      responses:
-#        200:
+#        "200":
 #          description: Successful operation
 #          schema:
 #            $ref: '#/definitions/file'
-#        400:
+#        "400":
 #          description: Invalid ID supplied
-#        404:
+#        "404":
 #          description: File not found
 ##      security:
 ##      - api_key: []
@@ -628,13 +607,13 @@ paths:
 #        required: false
 #        type: string
 #      responses:
-#        200:
+#        "200":
 #          description: Successful operation
 #          schema:
 #            type: array
 #            items:
 #              $ref: '#/definitions/file'
-#        400:
+#        "400":
 #          description: Error
 ##      security:
 ##      - rna_auth:
@@ -655,11 +634,11 @@ paths:
         required: true
         type: string
       responses:
-        200:
+        "200":
           description: Successful operation
-        400:
+        "400":
           description: Invalid ID supplied
-        404:
+        "404":
           description: File not found
 
 # TODO: delete this!!! only for demo use to set up some mock data with demo HDF5
@@ -670,13 +649,13 @@ paths:
 #        operationId: rnaget_service.api.operations.db_test_setup
 #        summary: test
 #        responses:
-#            201:
+#            "201":
 #              description: successful operation
 #              schema:
 #                type: array
 #                items:
 #                 $ref: '#/definitions/project'
-#            400:
+#            "400":
 #              description: Error
 
 definitions:


### PR DESCRIPTION
minor changes to use bravado's {'validate_swagger_spec': True} when loading schema